### PR TITLE
Feat(FE): skeleton 구현(Box, Text)

### DIFF
--- a/frontend/src/components/skeleton/BoxSkeleton.tsx
+++ b/frontend/src/components/skeleton/BoxSkeleton.tsx
@@ -1,0 +1,25 @@
+import { Suspense } from 'react'
+
+export default function BoxSkeleton({
+  className,
+  children,
+}: {
+  className?: string
+  children?: React.ReactNode | React.ReactNode[]
+}) {
+  return (
+    <div className={className}>
+      <Suspense
+        fallback={
+          <div className="h-full w-full animate-pulse">
+            <p className="h-full w-full rounded-md bg-gray-200">
+              <span className="hide"> Loading... </span>
+            </p>
+          </div>
+        }
+      >
+        {children}
+      </Suspense>
+    </div>
+  )
+}

--- a/frontend/src/components/skeleton/TextSkeleton.tsx
+++ b/frontend/src/components/skeleton/TextSkeleton.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from 'react'
+
+export default function TextSkeleton({
+  className,
+  children,
+  lines = 3,
+}: {
+  className?: string
+  children?: React.ReactNode | React.ReactNode[]
+  lines: number
+}) {
+  return (
+    <div className={className}>
+      <Suspense fallback={<div className="flex w-full animate-pulse flex-col gap-4">{getLines(lines)}</div>}>
+        {children}
+      </Suspense>
+    </div>
+  )
+}
+
+function getLines(lines: number) {
+  const textLines = Array(lines).fill('_')
+
+  return textLines.map((_, idx) => (
+    <p key={idx} className="h-full w-full rounded-md bg-gray-200">
+      <span className="hide"> Loading... </span>
+    </p>
+  ))
+}

--- a/frontend/src/components/skeleton/index.tsx
+++ b/frontend/src/components/skeleton/index.tsx
@@ -1,0 +1,4 @@
+import BoxSkeleton from './BoxSkeleton'
+import TextSkeleton from './TextSkeleton'
+
+export { BoxSkeleton, TextSkeleton }


### PR DESCRIPTION
사용을 원하는 컴포넌트를 skeleton 컴포넌트로 감싸서 사용
```ts
import {BoxSkeleton} from '/....'

// ... 생략

return (
  <BoxSkeleton> {자식 컴포넌트}  </BoxSkeleton>
)


```


테스트 시 React.lazy 함수로 렌더링을 지연
아래 함수를 사용해서 컴포넌트를 일정 시간 지난 후에 import 하도록 설정 가능
lazyMinLoadTime의 두번째 인자에 시간 입력

```ts
import React from 'react'

const lazyMinLoadTime = <T extends ComponentType<any>>(factory: () => Promise<{ default: T }>, minLoadTimeMs = 2000) =>
  lazy(() =>
    Promise.all([factory(), new Promise((resolve) => setTimeout(resolve, minLoadTimeMs))]).then(
      ([moduleExports]) => moduleExports,
    ),
  )

const ProjectCard = lazyMinLoadTime(() => import('./ProjectCard'), 3000)

```