### PR TITLE
Feat(BE): 아티스트 메인 이미지, 추가 이미지(다중), 프로젝트 이미지(다중) 업로드 구현

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -44,3 +44,5 @@ backend/src/main/resources/.env
 /backend/.env
 
 backend/.idea/
+
+**/aws.properties

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -54,6 +54,12 @@ dependencies {
 		exclude group: "org.hamcrest", module: "hamcrest-core"
 	}
 
+	//s3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	//file io
+	implementation 'commons-io:commons-io:2.6'
+
 }
 configurations {
 	all*.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'

--- a/backend/src/main/java/portfolio/backend/BackendApplication.java
+++ b/backend/src/main/java/portfolio/backend/BackendApplication.java
@@ -3,6 +3,7 @@ package portfolio.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;

--- a/backend/src/main/java/portfolio/backend/BackendApplication.java
+++ b/backend/src/main/java/portfolio/backend/BackendApplication.java
@@ -3,8 +3,8 @@ package portfolio.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -17,6 +17,7 @@ import portfolio.backend.authentication.config.properties.CorsProperties;
 		CorsProperties.class,
 		AppProperties.class
 })
+@PropertySource("classpath:/aws.properties")
 public class BackendApplication {
 
 

--- a/backend/src/main/java/portfolio/backend/api/artist/entity/Artist.java
+++ b/backend/src/main/java/portfolio/backend/api/artist/entity/Artist.java
@@ -8,6 +8,8 @@ import org.springframework.format.annotation.DateTimeFormat;
 import portfolio.backend.authentication.api.entity.user.User;
 
 import javax.persistence.*;
+import java.net.URI;
+import java.net.URL;
 import java.time.LocalDate;
 
 @Getter
@@ -48,11 +50,20 @@ public class Artist {
     private String snsLink;
 
     @Lob
-    private byte[] mainImage;
+    private String mainImage;
 
     @Column(nullable=true)
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate birthdate;
+
+
+    public String getMainImage() {
+        return mainImage;
+    }
+
+    public void setMainImage(String mainImage) {
+        this.mainImage = mainImage;
+    }
 
     public String getUserId() {
         return userId;
@@ -125,13 +136,7 @@ public class Artist {
         this.snsLink = snsLink;
     }
 
-    public byte[] getMainImage() {
-        return mainImage;
-    }
 
-    public void setMainImage(byte[] mainImage) {
-        this.mainImage = mainImage;
-    }
 
     public LocalDate getBirthdate() {
         return birthdate;

--- a/backend/src/main/java/portfolio/backend/api/artist/entity/Artist.java
+++ b/backend/src/main/java/portfolio/backend/api/artist/entity/Artist.java
@@ -52,6 +52,9 @@ public class Artist {
     @Lob
     private String mainImage;
 
+    @Lob
+    private String extraImage;
+
     @Column(nullable=true)
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate birthdate;
@@ -63,6 +66,14 @@ public class Artist {
 
     public void setMainImage(String mainImage) {
         this.mainImage = mainImage;
+    }
+
+    public String getExtraImage() {
+        return extraImage;
+    }
+
+    public void setExtraImage(String extraImage) {
+        this.extraImage = extraImage;
     }
 
     public String getUserId() {

--- a/backend/src/main/java/portfolio/backend/api/imageupload/controller/S3Controller.java
+++ b/backend/src/main/java/portfolio/backend/api/imageupload/controller/S3Controller.java
@@ -1,0 +1,23 @@
+package portfolio.backend.api.imageupload.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import portfolio.backend.api.imageupload.service.S3Service;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@RestController
+public class S3Controller {
+
+    private final S3Service s3Service;
+
+    @PostMapping
+    public void uploadFile(@RequestParam MultipartFile multipartFile)
+            throws IOException {
+        s3Service.saveUploadFile(multipartFile);
+    }
+
+
+}

--- a/backend/src/main/java/portfolio/backend/api/imageupload/entity/ExtraUploadFile.java
+++ b/backend/src/main/java/portfolio/backend/api/imageupload/entity/ExtraUploadFile.java
@@ -1,0 +1,25 @@
+package portfolio.backend.api.imageupload.entity;
+
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class ExtraUploadFile {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+    private String uploadFileName;
+    private String storeFileUrl;
+
+
+    public ExtraUploadFile(String uploadFileName, String storeFileUrl) {
+        this.uploadFileName = uploadFileName;
+        this.storeFileUrl = storeFileUrl;
+    }
+}

--- a/backend/src/main/java/portfolio/backend/api/imageupload/entity/ProjectUploadFile.java
+++ b/backend/src/main/java/portfolio/backend/api/imageupload/entity/ProjectUploadFile.java
@@ -1,0 +1,27 @@
+package portfolio.backend.api.imageupload.entity;
+
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class ProjectUploadFile {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+    private String uploadFileName;
+    private String storeFileUrl;
+
+
+
+
+    public ProjectUploadFile(String uploadFileName, String storeFileUrl) {
+        this.uploadFileName = uploadFileName;
+        this.storeFileUrl = storeFileUrl;
+    }
+}

--- a/backend/src/main/java/portfolio/backend/api/imageupload/entity/UploadFile.java
+++ b/backend/src/main/java/portfolio/backend/api/imageupload/entity/UploadFile.java
@@ -1,0 +1,25 @@
+package portfolio.backend.api.imageupload.entity;
+
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+public class UploadFile {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+    private String uploadFileName;
+    private String storeFileUrl;
+
+
+    public UploadFile(String uploadFileName, String storeFileUrl) {
+        this.uploadFileName = uploadFileName;
+        this.storeFileUrl = storeFileUrl;
+    }
+}

--- a/backend/src/main/java/portfolio/backend/api/imageupload/repository/ExtraUploadFileRepository.java
+++ b/backend/src/main/java/portfolio/backend/api/imageupload/repository/ExtraUploadFileRepository.java
@@ -1,0 +1,9 @@
+package portfolio.backend.api.imageupload.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import portfolio.backend.api.imageupload.entity.ExtraUploadFile;
+import portfolio.backend.api.imageupload.entity.ProjectUploadFile;
+
+public interface ExtraUploadFileRepository extends JpaRepository<ExtraUploadFile, Long> {
+
+}

--- a/backend/src/main/java/portfolio/backend/api/imageupload/repository/ProjectUploadFileRepository.java
+++ b/backend/src/main/java/portfolio/backend/api/imageupload/repository/ProjectUploadFileRepository.java
@@ -1,0 +1,9 @@
+package portfolio.backend.api.imageupload.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import portfolio.backend.api.imageupload.entity.ProjectUploadFile;
+import portfolio.backend.api.imageupload.entity.UploadFile;
+
+public interface ProjectUploadFileRepository extends JpaRepository<ProjectUploadFile, Long> {
+
+}

--- a/backend/src/main/java/portfolio/backend/api/imageupload/repository/UploadFileRepository.java
+++ b/backend/src/main/java/portfolio/backend/api/imageupload/repository/UploadFileRepository.java
@@ -1,0 +1,7 @@
+package portfolio.backend.api.imageupload.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import portfolio.backend.api.imageupload.entity.UploadFile;
+
+public interface UploadFileRepository extends JpaRepository<UploadFile, Long> {
+}

--- a/backend/src/main/java/portfolio/backend/api/imageupload/service/ProjectS3Service.java
+++ b/backend/src/main/java/portfolio/backend/api/imageupload/service/ProjectS3Service.java
@@ -1,0 +1,61 @@
+package portfolio.backend.api.imageupload.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import portfolio.backend.api.imageupload.entity.ProjectUploadFile;
+import portfolio.backend.api.imageupload.repository.ProjectUploadFileRepository;
+import portfolio.backend.api.project.repository.ProjectRepository;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class ProjectS3Service {
+
+    private final AmazonS3 amazonS3;
+    private final AmazonS3Client amazonS3Client;
+    private final ProjectRepository projectRepository;
+    private final ProjectUploadFileRepository projectUploadFileRepository;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    //project api image 저장
+    @Transactional
+    public String projectSaveUploadFile(MultipartFile ProjectMultipartFile) throws IOException {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(ProjectMultipartFile.getContentType());
+        objectMetadata.setContentLength(ProjectMultipartFile.getSize());
+
+        String ProjectOriginalFilename = ProjectMultipartFile.getOriginalFilename();
+        int ProjectIndex = ProjectOriginalFilename.lastIndexOf(".");
+        String ProjectExt = ProjectOriginalFilename.substring(ProjectIndex + 1);
+
+        String ProjectStoreFileName = UUID.randomUUID() + "." + ProjectExt;
+        String ProjectKey = "projectImage/" + ProjectStoreFileName;
+
+        try (InputStream inputStream = ProjectMultipartFile.getInputStream()) {
+            amazonS3Client.putObject(new PutObjectRequest(bucket, ProjectKey, inputStream, objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+        }
+
+        String ProjectStoreFileUrl = amazonS3Client.getUrl(bucket, ProjectKey).toString();
+        ProjectUploadFile projectUploadFile = new ProjectUploadFile(ProjectOriginalFilename, ProjectStoreFileUrl);
+        projectUploadFileRepository.save(projectUploadFile);
+
+        return ProjectKey;
+    }
+
+
+}

--- a/backend/src/main/java/portfolio/backend/api/imageupload/service/S3Service.java
+++ b/backend/src/main/java/portfolio/backend/api/imageupload/service/S3Service.java
@@ -1,0 +1,54 @@
+package portfolio.backend.api.imageupload.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import portfolio.backend.api.imageupload.entity.UploadFile;
+import portfolio.backend.api.imageupload.repository.UploadFileRepository;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class S3Service {
+
+    private final AmazonS3Client amazonS3Client;
+    private final UploadFileRepository uploadFileRepository;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Transactional
+    public String saveUploadFile(MultipartFile multipartFile) throws IOException {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(multipartFile.getContentType());
+        objectMetadata.setContentLength(multipartFile.getSize());
+
+        String originalFilename = multipartFile.getOriginalFilename();
+        int index = originalFilename.lastIndexOf(".");
+        String ext = originalFilename.substring(index + 1);
+
+        String storeFileName = UUID.randomUUID() + "." + ext;
+        String key = "test/" + storeFileName;
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            amazonS3Client.putObject(new PutObjectRequest(bucket, key, inputStream, objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+        }
+
+        String storeFileUrl = amazonS3Client.getUrl(bucket, key).toString();
+        UploadFile uploadFile = new UploadFile(originalFilename, storeFileUrl);
+        uploadFileRepository.save(uploadFile);
+
+        return key;
+    }
+
+}

--- a/backend/src/main/java/portfolio/backend/api/project/entity/Project.java
+++ b/backend/src/main/java/portfolio/backend/api/project/entity/Project.java
@@ -60,8 +60,9 @@ public class Project {
     private List<RequiredCategory> requiredCategory;
     private Boolean swipeAlgorithm;
 
-    @Column(nullable=true)
+    @Lob
     private String image;
+
     @Column(nullable=false)
     private Integer liked = 0;
 

--- a/backend/src/main/resources/application-docker.yml
+++ b/backend/src/main/resources/application-docker.yml
@@ -115,8 +115,8 @@ app:
 cloud:
   aws:
     credentials:
-      accessKey: AKIAUBH4OPSWTXJH2FP5
-      secretKey: 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
+      accessKey: ${accessKey}
+      secretKey: ${secretKey}
     region:
       static: ap-northeast-2
     stack:

--- a/backend/src/main/resources/application-docker.yml
+++ b/backend/src/main/resources/application-docker.yml
@@ -8,7 +8,7 @@ spring:
   jpa:
     generate-ddl: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:
@@ -19,6 +19,11 @@ spring:
         jdbc.batch_size: 20
         order_inserts: true
         format_sql: true
+
+  servlet:
+    multipart:
+      maxFileSize: 50MB
+      maxRequestSize: 50MB
 
   thymeleaf:
     prefix: classpath:/templates/
@@ -52,13 +57,13 @@ spring:
               - profile_name
             client-name: Naver
             authorization-grant-type: authorization_code
-#            redirect-uri: http://localhost:7072/login/oauth2/code/naver
+            #            redirect-uri: http://localhost:7072/login/oauth2/code/naver
             redirectUri: "{baseUrl}/{action}/oauth2/code/{registrationId}"
 
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-#            redirect-uri: http://localhost:7072/login/oauth2/code/kakao
+            #            redirect-uri: http://localhost:7072/login/oauth2/code/kakao
             redirectUri: "{baseUrl}/{action}/oauth2/code/{registrationId}"
             authorization-grant-type: authorization_code
             client-authentication-method: POST
@@ -105,3 +110,16 @@ app:
   oauth2:
     authorizedRedirectUris:
       - http://localhost:3000/oauth/redirect
+
+# aws s3 bucket
+cloud:
+  aws:
+    credentials:
+      accessKey: AKIAUBH4OPSWTXJH2FP5
+      secretKey: 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
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    s3:
+      bucket: atogatobucket

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,4 +1,3 @@
-
 spring:
   profiles:
     active: docker
@@ -13,7 +12,7 @@ spring:
   jpa:
     generate-ddl: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:
@@ -24,6 +23,11 @@ spring:
         jdbc.batch_size: 20
         order_inserts: true
         format_sql: true
+
+  servlet:
+    multipart:
+      maxFileSize: 50MB
+      maxRequestSize: 50MB
 
   thymeleaf:
     prefix: classpath:/templates/
@@ -57,14 +61,14 @@ spring:
               - profile_name
             client-name: Naver
             authorization-grant-type: authorization_code
-#            redirect-uri: http://localhost:7072/login/oauth2/code/naver
+            #            redirect-uri: http://localhost:7072/login/oauth2/code/naver
             redirectUri: "{baseUrl}/{action}/oauth2/code/{registrationId}"
 
 
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-#            redirect-uri: http://localhost:7072/login/oauth2/code/kakao
+            #            redirect-uri: http://localhost:7072/login/oauth2/code/kakao
             redirectUri: "{baseUrl}/{action}/oauth2/code/{registrationId}"
             authorization-grant-type: authorization_code
             client-authentication-method: POST
@@ -72,7 +76,7 @@ spring:
             scope:
               - profile_nickname
               - account_email
-#  http://localhost:8080/oauth2/authorization/{provider-id}?redirect_uri=http://localhost:3000/oauth/redirect
+        #  http://localhost:8080/oauth2/authorization/{provider-id}?redirect_uri=http://localhost:3000/oauth/redirect
 
         provider:
           naver:
@@ -113,4 +117,16 @@ app:
     authorizedRedirectUris:
       - http://localhost:3000/oauth/redirect
 
+# aws s3 bucket
+cloud:
+  aws:
+    credentials:
+      accessKey: AKIAUBH4OPSWTXJH2FP5
+      secretKey: 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
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    s3:
+      bucket: atogatobucket
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -121,8 +121,8 @@ app:
 cloud:
   aws:
     credentials:
-      accessKey: AKIAUBH4OPSWTXJH2FP5
-      secretKey: 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
+      accessKey: ${accessKey}
+      secretKey: ${secretKey}
     region:
       static: ap-northeast-2
     stack:


### PR DESCRIPTION
현재 아티스트 메인 이미지, 추가 이미지(다중), 프로젝트 이미지(다중)  s3 버킷 저장과 url db저장, 이미지 불러오기까지 완료 됐고
이미지 삭제나 수정을 추가로 구현해볼 예정입니다.
aws 관련 민감정보들은 환경변수와 어노테이션을 사용해서 처리했습니다!


